### PR TITLE
Don't include foreman in your gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,6 @@ gem 'rails', '~> 6.0.0'
 gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
-# Manage Procfile-based applications
-# https://github.com/ddollar/foreman
-gem 'foreman', '~> 0.63'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,6 @@ GEM
       dry-inflector (~> 0.1)
     erubi (1.9.0)
     ffi (1.11.1)
-    foreman (0.86.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.7.0)
@@ -230,7 +229,6 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
-  foreman (~> 0.63)
   karafka (~> 1.3)
   listen (>= 3.0.5, < 3.2)
   pg
@@ -244,4 +242,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.0.2
+   2.1.4


### PR DESCRIPTION
Ruby users should take care not to install foreman in their project's Gemfile.

See: https://github.com/ddollar/foreman/wiki/Don't-Bundle-Foreman